### PR TITLE
Add dynamic thinking logic

### DIFF
--- a/Agent.py
+++ b/Agent.py
@@ -83,6 +83,18 @@ class Agent:
             for n in self.neurons:
                 n.update()
 
+    def think_until_convergence(self, max_rounds=20, threshold=0.001):
+        """Iterate until neuron states stabilize or max_rounds reached."""
+        prev = [n.state for n in self.neurons]
+        for i in range(1, max_rounds + 1):
+            self.step(1)
+            curr = [n.state for n in self.neurons]
+            diff = max(abs(a - b) for a, b in zip(prev, curr))
+            if diff < threshold:
+                return i
+            prev = curr
+        return max_rounds
+
     def learn(self, reward_value): # Renamed 'won' to 'reward_value' for clarity
         for syn in self.synapses:
             syn.update_weight(reward_value) # Pass the numerical reward

--- a/evolution_chess.py
+++ b/evolution_chess.py
@@ -52,7 +52,7 @@ def play_game(agent_white, agent_black, max_moves=40):
         agent.reset()
         inputs = encode_board(board)
         agent.receive_inputs(inputs)
-        agent.step(think=2)
+        agent.think_until_convergence()
         move = choose_move(agent, board)
         if move is None or move not in board.legal_moves:
             move = random.choice(list(board.legal_moves))
@@ -120,7 +120,7 @@ def play_game_vs_stockfish(agent, engine, play_as_white=True, max_moves=40, dept
             agent.reset()
             inputs = encode_board(board)
             agent.receive_inputs(inputs)
-            agent.step(think=2)
+            agent.think_until_convergence()
             move = choose_move(agent, board)
             if move is None or move not in board.legal_moves:
                 move = random.choice(list(board.legal_moves))


### PR DESCRIPTION
## Summary
- add a convergence-based thinking loop for the agent
- allow game routines to use the new loop

## Testing
- `python -m py_compile Agent.py evolution_chess.py mutations.py config.py`
- `python - <<'PY'
from Agent import Agent
agent = Agent('test', 5)
agent.receive_inputs([0.1]*5)
steps = agent.think_until_convergence(max_rounds=10)
print('steps', steps)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68516a448a90832bb9b3345b4c0a590a